### PR TITLE
Add access token to board

### DIFF
--- a/app/Filament/Resources/BoardResource.php
+++ b/app/Filament/Resources/BoardResource.php
@@ -32,7 +32,11 @@ class BoardResource extends Resource
         return $form
             ->columns(1)
             ->schema([
-                TextInput::make('name'),
+                TextInput::make('name')
+                    ->required(),
+                TextInput::make('token')
+                    ->helperText('String to secure your board\'s public link. Use lowercase letters, and use dashes instead of spaces.')
+                    ->required(),
                 Builder::make('tiles')
                     ->addActionLabel('Add a new tile')
                     ->blockNumbers(false)
@@ -158,7 +162,7 @@ class BoardResource extends Resource
                                             ->email()
                                             ->required(),
                                     )
-                                    ->helperText('Share your calendar with `newhouse-dashboard@home-dashboard-169916.iam.gserviceaccount.com`'),
+                                    ->helperText('Share your calendar with `hootie@home-dashboard-169916.iam.gserviceaccount.com`'),
                                 self::getSizeFieldset(),
                                 self::getTypeField('livewire'),
                             ]),

--- a/app/Filament/Resources/BoardResource/Pages/EditBoard.php
+++ b/app/Filament/Resources/BoardResource/Pages/EditBoard.php
@@ -17,7 +17,7 @@ class EditBoard extends EditRecord
     {
         return [
             Action::make('preview')
-                ->url(url('boards/' . $this->getRecord()->id), shouldOpenInNewTab: true),
+                ->url(url('boards/' . $this->getRecord()->id . '?token=' . $this->getRecord()->token), shouldOpenInNewTab: true),
             DeleteAction::make(),
         ];
     }

--- a/database/factories/BoardFactory.php
+++ b/database/factories/BoardFactory.php
@@ -13,6 +13,8 @@ class BoardFactory extends Factory
     {
         return [
             'name' => fake()->name(),
+            'token' => 'hootie',
+            'tiles' => [],
         ];
     }
 }

--- a/database/migrations/2024_03_07_172833_add_token_to_boards.php
+++ b/database/migrations/2024_03_07_172833_add_token_to_boards.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('boards', function (Blueprint $table) {
+            $table->string('token')->after('name');
+        });
+    }
+};

--- a/resources/views/pages/boards/[Board].blade.php
+++ b/resources/views/pages/boards/[Board].blade.php
@@ -1,8 +1,22 @@
 <?php
 
+use App\Models\Board;
+use App\Models\Post;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
 use function Laravel\Folio\name;
+use function Laravel\Folio\render;
 
 name('boards.show');
+
+render(function (View $view, Board $board) {
+    if (! request()->has('token') || request()->get('token') !== $board->token) {
+        return response('Not Found', 404);
+    }
+
+    return $view;
+});
 
 ?>
 

--- a/resources/views/pages/boards/[Board].blade.php
+++ b/resources/views/pages/boards/[Board].blade.php
@@ -4,6 +4,7 @@ use App\Models\Board;
 use App\Models\Post;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 use function Laravel\Folio\name;
 use function Laravel\Folio\render;
@@ -12,7 +13,7 @@ name('boards.show');
 
 render(function (View $view, Board $board) {
     if (! request()->has('token') || request()->get('token') !== $board->token) {
-        return response('Not Found', 404);
+        throw new NotFoundHttpException();
     }
 
     return $view;

--- a/tests/Feature/Pages/BoardTest.php
+++ b/tests/Feature/Pages/BoardTest.php
@@ -14,7 +14,7 @@ it('can be viewed', function () {
                 ],
                 'type' => 'clock-analog',
             ],
-        ]
+        ],
     ]);
 
     $this->get(route('boards.show', ['board' => $board, 'token' => $board->token]))
@@ -31,7 +31,7 @@ it('cannot be viewed without token', function () {
 
 it('cannot be viewed if token does not match', function () {
     $board = Board::factory()->create([
-        'token' => 'hootie'
+        'token' => 'hootie',
     ]);
 
     $this->get(route('boards.show', ['board' => $board, 'token' => 'king']))

--- a/tests/Feature/Pages/BoardTest.php
+++ b/tests/Feature/Pages/BoardTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Board;
+
+it('can be viewed', function () {
+    $board = Board::factory()->create([
+        'tiles' => [
+            [
+                'data' => [
+                    'type' => 'blade',
+                    'width' => 1,
+                    'height' => 1,
+                    'timezone' => 'America/Chicago',
+                ],
+                'type' => 'clock-analog',
+            ],
+        ]
+    ]);
+
+    $this->get(route('boards.show', ['board' => $board, 'token' => $board->token]))
+        ->assertOk()
+        ->assertSee('clock');
+});
+
+it('cannot be viewed without token', function () {
+    $board = Board::factory()->create();
+
+    $this->get(route('boards.show', ['board' => $board]))
+        ->assertStatus(404);
+});
+
+it('cannot be viewed if token does not match', function () {
+    $board = Board::factory()->create([
+        'token' => 'hootie'
+    ]);
+
+    $this->get(route('boards.show', ['board' => $board, 'token' => 'king']))
+        ->assertStatus(404);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,11 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
I added a `token` variable to the board for some security. It's not a foolproof solution, but good enough for this use case. 

- When creating a board, the user is now given the option to add a token.
- When previewing a board, the action adds the token as a query string to the URL
- When accessing a board, a user will see a 404 if the token does not exist
- When accessing a board, a user will see a 404 if the token does not match