### PR TITLE
Add scheduled command to reset status after two hours

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
@@ -11,3 +12,11 @@ Artisan::command('inspire', function () {
 Schedule::command('board:fetch-calendar-events')->everyMinute();
 Schedule::command('board:fetch-weather')->everyFifteenMinutes();
 Schedule::command('board:fetch-pressure')->everyFifteenMinutes();
+
+Artisan::command('app:clear-status', function () {
+    $twoHoursAgo = now()->subHours(2);
+
+    User::whereNotNull('status')
+        ->where('updated_at', $twoHoursAgo)
+        ->update(['status' => null]);
+})->purpose('Clear stale statuses')->hourly();

--- a/tests/Feature/Commands/ClearStatusTest.php
+++ b/tests/Feature/Commands/ClearStatusTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+it('clears status after two hours of inactivity', function () {
+    $user = User::factory()->create(['status' => 'pairing']);
+
+    Carbon::setTestNow(now()->addHours(2));
+
+    $this->artisan('app:clear-status');
+
+    expect($user->fresh()->status)->toBeNull();
+});
+
+it('does not clear status before two hours of inactivity', function () {
+    $user = User::factory()->create(['status' => 'pairing']);
+
+    Carbon::setTestNow(now()->addHour());
+
+    $this->artisan('app:clear-status');
+
+    expect($user->fresh()->status)->toBe('pairing');
+});
+
+it('does not update null status', function () {
+    $user = User::factory()->create(['status' => null]);
+    $oldUpdatedAt = $user->updated_at->toDateTimeString();
+
+    Carbon::setTestNow(now()->addHours(2));
+
+    $this->artisan('app:clear-status');
+
+    expect($user->fresh()->updated_at->toDateTimeString())->toBe($oldUpdatedAt);
+});


### PR DESCRIPTION
Sometimes I forget to update my status, so this clears it out if the user hasn't been updated in the last two hours.